### PR TITLE
NimLime didnt work on Win 8.1 machines

### DIFF
--- a/AutoComplete.py
+++ b/AutoComplete.py
@@ -121,12 +121,12 @@ class NimrodCompleter(sublime_plugin.EventListener):
         dirtyFile = None
         compiler = settings.get("nimrod_compiler_executable")
         if compiler == None or compiler == "": return []
-        pargs = compiler + " --verbosity:0 idetools --suggest "
+        pargs = compiler + " --verbosity:0 idetools "
 
         if view.is_dirty():
             #Generate dirty file
             size = view.size()
-            dirtyFile = tempfile.NamedTemporaryFile(suffix=".nim", delete=True)
+            dirtyFile = tempfile.NamedTemporaryFile(suffix=".nim", delete=False)
             dirtyFileName = dirtyFile.name
             dirtyFile.file.write(
                 view.substr(sublime.Region(0, size)).encode("UTF-8")
@@ -138,7 +138,7 @@ class NimrodCompleter(sublime_plugin.EventListener):
 
         pargs = pargs + filename \
          + "," + str(line) + "," + str(col) \
-         + " " + projFile
+         + " --suggest " + projFile
 
         print(pargs)
 
@@ -194,6 +194,9 @@ class NimrodCompleter(sublime_plugin.EventListener):
         # Delete the dirty file
         if dirtyFile != None:
             dirtyFile.close()
-
+            try:
+                os.unlink(dirtyFile.name)
+            except OSError:
+                pass
         # get results from each tab
         return results # sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS

--- a/Lookup.py
+++ b/Lookup.py
@@ -23,7 +23,7 @@ class LookupCommand(sublime_plugin.TextCommand):
             # Generate temp file
             size = self.view.size()
 
-            with tempfile.NamedTemporaryFile(suffix=".nim", delete=True) as dirtyFile:
+            with tempfile.NamedTemporaryFile(suffix=".nim", delete=False) as dirtyFile:
                 dirtyFileName = dirtyFile.name
                 dirtyFile.file.write(
                     self.view.substr(sublime.Region(0, size)).encode("UTF-8")
@@ -33,9 +33,13 @@ class LookupCommand(sublime_plugin.TextCommand):
                 result = Idetools.idetool(self.view.window(), "--def", filename, line, col, dirtyFile.name)
                 dirtyFile.close();
 
+
+            try:
+                os.unlink(dirtyFile.name)
+            except OSError:
+                pass
         else:
-            result = Idetools.idetool(
-                self.view.window(), "--def", filename, line, col)
+            result = Idetools.idetool(self.view.window(), "--def", filename, line, col)
 
         # Parse the result
         value = Idetools.parse(result)

--- a/Nimrod.py
+++ b/Nimrod.py
@@ -76,9 +76,9 @@ class Idetools:
             if compiler == None or compiler == "": return ""
 
             args = compiler + " --verbosity:0 idetools " \
-                + cmd + trackType \
+                + trackType \
                 + "\"" + filePath + "," + str(line) + "," + str(col) \
-                + "\" \"" + projFile + "\"" + extra
+                + "\" " + cmd + " \"" + projFile + "\"" + extra
             print(args)
 
             output = subprocess.Popen(args,
@@ -89,7 +89,7 @@ class Idetools:
 
             result = ""
 
-            for temp in output.stdout: pass
+            temp = output.stdout.read()
 
             # Convert bytes to string
             result = temp.decode('utf-8')


### PR DESCRIPTION
Moved the --def command to the right position before projfile in the nimrod idetools command.
Set delete=False in NamedTemporaryFile() and deleted the file manually using os.unlink since windows dont let you open a file for write and then read it, and closing it deleted the file.

But Im no Python dev so right me if im wrong. 
