### PR TITLE
Error regexes in sublime-build

### DIFF
--- a/nim.sublime-build
+++ b/nim.sublime-build
@@ -1,6 +1,8 @@
 {
     "cmd": ["nim", "c", "--parallelBuild:1", "$file"],
     "selector": "source.nim",
+    "file_regex": "^(.+.nim)\\((\\d+), (\\d+)\\) (.*)",
+    "line_regex": "Error:",
 
     "variants": [
         {


### PR DESCRIPTION
This lets sublime figure out where errors are (pressing f4 jumps to error)

If you also have the Highlight Build Errors plugin installed it looks like this:

![screen shot 2015-01-25 at 6 03 16 pm](https://cloud.githubusercontent.com/assets/134706/5893714/b7c14dce-a4bc-11e4-8654-39cdd965589e.png)
