### PR TITLE
Added contribution-friendly readme and */= in proc... highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,16 @@ Features
 Installation
 ------------
 
-Clone the repository in your Sublime package directory
+###Latest
+
+* Summon the command palette and select `Package Control: Add repository`
+* Enter the project's URL (no .git extension!)
+* Install `NimLime` through Package Control
+
+###Stable
+
+* Install `NimLime` through Package Control (this version is usually older than the one here)
+
 
 Settings
 --------
@@ -33,3 +42,17 @@ Checking the current file automatically on-save can be enabled through the setti
 
 The path to the compiler can be configured through the setting `nim_compiler_executable`.
 Per default it is set to `nim`, which means that the compiler must be in your `PATH` for the plugin to work.
+
+
+Contributing
+------------
+
+Pull requests are welcome!
+
+Clone the repository in your Sublime package directory.
+
+Install the [AAAPackageDev](https://github.com/SublimeText/AAAPackageDev).
+
+Modify the `.YAML-tmLanguage` files and regenerate the `.tmLanguage` files
+by summoning the command palette and selecting the `Convert (YAML, JSON, PLIST) to...`
+command. Don't modify the `.tmLanguage` files, they will be overwritten!

--- a/nim.YAML-tmLanguage
+++ b/nim.YAML-tmLanguage
@@ -59,10 +59,13 @@ patterns:
   name: meta.proc.nim
   patterns:
   - begin: \b(proc|method|template|macro|iterator|converter)\s+(\`([^\s\`]+)\`|(\w+))(\*)?
-    end: \=
-    captures:
+    end: (\=)
+    beginCaptures:
       '1': {name: storage.type.proc.nim}
       '2': {name: entity.name.function.nim}
+      '5': {name: keyword.operator.nim}
+    endCaptures:
+      '1': {name: keyword.operator.nim}
     patterns:
       - comment: Generic
         match: \[\w+\]

--- a/nim.tmLanguage
+++ b/nim.tmLanguage
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
@@ -164,7 +164,7 @@
 				<dict>
 					<key>begin</key>
 					<string>\b(proc|method|template|macro|iterator|converter)\s+(\`([^\s\`]+)\`|(\w+))(\*)?</string>
-					<key>captures</key>
+					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
 						<dict>
@@ -176,9 +176,22 @@
 							<key>name</key>
 							<string>entity.name.function.nim</string>
 						</dict>
+						<key>5</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.nim</string>
+						</dict>
 					</dict>
 					<key>end</key>
-					<string>\=</string>
+					<string>(\=)</string>
+					<key>endCaptures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.operator.nim</string>
+						</dict>
+					</dict>
 					<key>patterns</key>
 					<array>
 						<dict>


### PR DESCRIPTION
I would like to help out with the syntax highlighting since I did some for myself ([Nimrod-Sublime-Syntax
](https://github.com/fenekku/Nimrod-Sublime-Syntax)). If this is ok I will port other changes.

Here I simply made the '*' recognized as a keyword when used in procs, templates,,, I also made the '=' recognized. This is to be consistent with their appearance in other scopes. I also added some details to the README because I had to figure those things out for myself.