### PR TITLE
made strings, escape characters and single quotes :sparkles:

### DIFF
--- a/nim.YAML-tmLanguage
+++ b/nim.YAML-tmLanguage
@@ -115,19 +115,19 @@ patterns:
 
 - comment: A hexadecimal literal
   name: constant.numeric.integer.hexadecimal.nim
-  match: \b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?
+  match: \b(0[xX]\h[_\h]*)('(([iIuUfF](8|16|32|64))|[uU]))?
 
 - comment: A base-8 integer literal
   name: constant.numeric.integer.octal.nim
-  match: \b(0o[0-7][_0-7]*)('[iIuUfF](8|16|32|64))?
+  match: \b(0o[0-7][_0-7]*)('(([iIuUfF](8|16|32|64))|[uU]))?
 
 - comment: A base-2 integer literal
   name: constant.numeric.integer.binary.nim
-  match: \b(0(b|B)[01][_01]*)('[iIuUfF](8|16|32|64))?
+  match: \b(0(b|B)[01][_01]*)('(([iIuUfF](8|16|32|64))|[uU]))?
 
 - comment: A base-10 integer literal
   name: constant.numeric.integer.decimal.nim
-  match: \b(\d[_\d]*)('[iIuUfF](8|16|32|64))?
+  match: \b(\d[_\d]*)('(([iIuUfF](8|16|32|64))|[uU]))?
 
 - comment: Language Constants.
   name: constant.language.nim
@@ -201,8 +201,8 @@ patterns:
 
 - comment: (Raw) Triple Quoted String
   name: string.quoted.triple.nim
-  begin: \"\"\"
-  end: \"\"\"
+  begin: r?\"\"\"
+  end: \"\"\"[^\"]
 
 - comment: Raw Double Quoted String
   name: string.quoted.double.raw.nim
@@ -215,14 +215,19 @@ patterns:
   name: string.quoted.double.nim
   begin: \"
   end: \"
-  captures:
-    '1': { name: storage.type.function.nim }
   patterns:
-  - match: (\\([abenrclftv\\]|["']|[0-9])|x\h\h)
+    - include: '#escaped_char'
 
 - comment: Single quoted character literal
   name: string.quoted.single.nim
-  match: \'(\\\d{1,3}|\\?[^\n]?)\'
+  begin: \'
+  end: \'
+  patterns:
+    - name: invalid.illegal.character.nim
+      match: \\n
+    - include: '#escaped_char'
+    - name: invalid.illegal.character.nim
+      match: ([^\']{2,}?)
 
 - comment: Call syntax
   begin: ([\w\`]+)\s*(?=\(|\[.+?\]\s*\()
@@ -501,4 +506,37 @@ patterns:
     - match: (?<!\$)(\$[a-zA-Z0-9_]+)
       name: keyword.operator.nim
     - {include: text.html.markdown.multimarkdown}
+
+
+repository:
+  escaped_char:
+    patterns:
+    - name: constant.character.escape.newline.nim
+      match: \\[nN]
+    - name: constant.character.escape.carriagereturn.nim
+      match: \\[cC]|\\[rR]
+    - name: constant.character.escape.linefeed.nim
+      match: \\[lL]
+    - name: constant.character.escape.formfeed.nim
+      match: \\[fF]
+    - name: constant.character.escape.tabulator.nim
+      match: \\[tT]
+    - name: constant.character.escape.verticaltabulator.nim
+      match: \\[vV]
+    - name: constant.character.escape.double-quote.nim
+      match: \\\"
+    - name: constant.character.escape.single-quote.nim
+      match: \\'
+    - name: constant.character.escape.chardecimalvalue.nim
+      match: \\[0-9]+
+    - name: constant.character.escape.alert.nim
+      match: \\[aA]
+    - name: constant.character.escape.backspace.nim
+      match: \\[bB]
+    - name: constant.character.escape.escape.nim
+      match: \\[eE]
+    - name: constant.character.escape.hex.nim
+      match: \\[xX]\h\h
+    - name: constant.character.escape.backslash.nim
+      match: \\\\
 ...

--- a/nim.tmLanguage
+++ b/nim.tmLanguage
@@ -320,7 +320,7 @@
 			<key>comment</key>
 			<string>A hexadecimal literal</string>
 			<key>match</key>
-			<string>\b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?</string>
+			<string>\b(0[xX]\h[_\h]*)('(([iIuUfF](8|16|32|64))|[uU]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.nim</string>
 		</dict>
@@ -328,7 +328,7 @@
 			<key>comment</key>
 			<string>A base-8 integer literal</string>
 			<key>match</key>
-			<string>\b(0o[0-7][_0-7]*)('[iIuUfF](8|16|32|64))?</string>
+			<string>\b(0o[0-7][_0-7]*)('(([iIuUfF](8|16|32|64))|[uU]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.octal.nim</string>
 		</dict>
@@ -336,7 +336,7 @@
 			<key>comment</key>
 			<string>A base-2 integer literal</string>
 			<key>match</key>
-			<string>\b(0(b|B)[01][_01]*)('[iIuUfF](8|16|32|64))?</string>
+			<string>\b(0(b|B)[01][_01]*)('(([iIuUfF](8|16|32|64))|[uU]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.binary.nim</string>
 		</dict>
@@ -344,7 +344,7 @@
 			<key>comment</key>
 			<string>A base-10 integer literal</string>
 			<key>match</key>
-			<string>\b(\d[_\d]*)('[iIuUfF](8|16|32|64))?</string>
+			<string>\b(\d[_\d]*)('(([iIuUfF](8|16|32|64))|[uU]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.decimal.nim</string>
 		</dict>
@@ -517,11 +517,11 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\"\"\"</string>
+			<string>r?\"\"\"</string>
 			<key>comment</key>
 			<string>(Raw) Triple Quoted String</string>
 			<key>end</key>
-			<string>\"\"\"</string>
+			<string>\"\"\"[^\"]</string>
 			<key>name</key>
 			<string>string.quoted.triple.nim</string>
 		</dict>
@@ -545,14 +545,6 @@
 		<dict>
 			<key>begin</key>
 			<string>\"</string>
-			<key>captures</key>
-			<dict>
-				<key>1</key>
-				<dict>
-					<key>name</key>
-					<string>storage.type.function.nim</string>
-				</dict>
-			</dict>
 			<key>comment</key>
 			<string>Double Quoted String</string>
 			<key>end</key>
@@ -562,18 +554,39 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>(\\([abenrclftv\\]|["']|[0-9])|x\h\h)</string>
+					<key>include</key>
+					<string>#escaped_char</string>
 				</dict>
 			</array>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>\'</string>
 			<key>comment</key>
 			<string>Single quoted character literal</string>
-			<key>match</key>
-			<string>\'(\\\d{1,3}|\\?[^\n]?)\'</string>
+			<key>end</key>
+			<string>\'</string>
 			<key>name</key>
 			<string>string.quoted.single.nim</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\n</string>
+					<key>name</key>
+					<string>invalid.illegal.character.nim</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#escaped_char</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>([^\']{2,}?)</string>
+					<key>name</key>
+					<string>invalid.illegal.character.nim</string>
+				</dict>
+			</array>
 		</dict>
 		<dict>
 			<key>begin</key>
@@ -1554,6 +1567,99 @@
 			</array>
 		</dict>
 	</array>
+	<key>repository</key>
+	<dict>
+		<key>escaped_char</key>
+		<dict>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>match</key>
+					<string>\\[nN]</string>
+					<key>name</key>
+					<string>constant.character.escape.newline.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[cC]|\\[rR]</string>
+					<key>name</key>
+					<string>constant.character.escape.carriagereturn.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[lL]</string>
+					<key>name</key>
+					<string>constant.character.escape.linefeed.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[fF]</string>
+					<key>name</key>
+					<string>constant.character.escape.formfeed.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[tT]</string>
+					<key>name</key>
+					<string>constant.character.escape.tabulator.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[vV]</string>
+					<key>name</key>
+					<string>constant.character.escape.verticaltabulator.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\\"</string>
+					<key>name</key>
+					<string>constant.character.escape.double-quote.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\'</string>
+					<key>name</key>
+					<string>constant.character.escape.single-quote.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[0-9]+</string>
+					<key>name</key>
+					<string>constant.character.escape.chardecimalvalue.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[aA]</string>
+					<key>name</key>
+					<string>constant.character.escape.alert.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[bB]</string>
+					<key>name</key>
+					<string>constant.character.escape.backspace.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[eE]</string>
+					<key>name</key>
+					<string>constant.character.escape.escape.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\[xX]\h\h</string>
+					<key>name</key>
+					<string>constant.character.escape.hex.nim</string>
+				</dict>
+				<dict>
+					<key>match</key>
+					<string>\\\\</string>
+					<key>name</key>
+					<string>constant.character.escape.backslash.nim</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>scopeName</key>
 	<string>source.nim</string>
 	<key>uuid</key>


### PR DESCRIPTION
Couple of additions:

- escape characters are emphasized in double quoted strings
- escape characters are ignored in raw or triple quoted strings
- the manual's quadruple quoted string example is highlighted correctly
- single quotes only allow single characters or valid character literals (not `\n`)
- incorrect single quote content is highlighted
- numerical constants with type suffix `'u` followed by nothing are highlighted
- uppercase handling of escape characters