### PR TITLE
Added `any` to types

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -234,7 +234,7 @@ patterns:
 
 - comment: Built-in, concrete types.
   name: storage.type.concrete.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr)(?![\w\x{80}-\x{10FFFF}])
+  match: (?<![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr|any)(?![\w\x{80}-\x{10FFFF}])
 
 - comment: Built-in, generic types.
   name: storage.type.generic.nim


### PR DESCRIPTION
`any` is equivalent to `distinct auto`, as mentioned in http://nim-lang.org/docs/manual.html#generics-type-classes. I'm not sure how often it's really used, but it at least shows up in some tests (like https://github.com/Araq/Nim/blob/00a702baeb4ad5e55811ec7b0fbecafa69ef412a/tests/generics/mdotlookup.nim#L1)