### PR TITLE
Added any keyword

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -234,7 +234,7 @@ patterns:
 
 - comment: Built-in, concrete types.
   name: storage.type.concrete.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr)(?![\w\x{80}-\x{10FFFF}])
+  match: (?<![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr|any)(?![\w\x{80}-\x{10FFFF}])
 
 - comment: Built-in, generic types.
   name: storage.type.generic.nim

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -638,7 +638,7 @@
 			<key>comment</key>
 			<string>Built-in, concrete types.</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr)(?![\w\x{80}-\x{10FFFF}])</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(((uint|int|float)(8|16|32|64)?)|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr|any)(?![\w\x{80}-\x{10FFFF}])</string>
 			<key>name</key>
 			<string>storage.type.concrete.nim</string>
 		</dict>


### PR DESCRIPTION
`any` is equivalent to `distinct auto`, as mentioned in http://nim-lang.org/docs/manual.html#generics-type-classes. I'm not sure how often it's really used, but it at least shows up in some tests (like https://github.com/Araq/Nim/blob/devel/tests/generics/mdotlookup.nim#L1)