### PR TITLE
Add support for changing `nim check --verbosity` level

### DIFF
--- a/NimCheck.py
+++ b/NimCheck.py
@@ -78,7 +78,7 @@ class NimCheckCurrentView(NimLimeOutputMixin, ApplicationCommand):
         self.list_errors = get('{0}.list.show_errors', True)
         self.list_warnings = get('{0}.list.show_warnings', True)
         self.move_cursor = get('{0}.list.move_cursor', True)
-        
+
     @send_self
     def run(self, show_error_list=True):
         this = yield
@@ -97,7 +97,7 @@ class NimCheckCurrentView(NimLimeOutputMixin, ApplicationCommand):
         # Run 'nim check' on the current view and retrieve the output.
         output, returncode = yield Thread(
             target=run_nimcheck,
-            args=(view.file_name(), this.send, this.verbosity)
+            args=(view.file_name(), this.send, self.verbosity)
         ).start()
 
         messages = parse_nimcheck_output(output)
@@ -275,7 +275,6 @@ class NimCheckFile(NimLimeOutputMixin, ApplicationCommand):
         )
 
         yield
-
 
 
 # Utility functions

--- a/NimCheck.py
+++ b/NimCheck.py
@@ -72,12 +72,13 @@ class NimCheckCurrentView(NimLimeOutputMixin, ApplicationCommand):
         get = self.get_setting
 
         self.highlight_errors = get('{0}.highlight_errors', True)
+        self.verbosity = get('{0}.verbosity', 2)
         self.highlight_warnings = get('{0}.highlight_warnings', True)
         self.include_context = get('{0}.list.include_context', True)
         self.list_errors = get('{0}.list.show_errors', True)
         self.list_warnings = get('{0}.list.show_warnings', True)
         self.move_cursor = get('{0}.list.move_cursor', True)
-
+        
     @send_self
     def run(self, show_error_list=True):
         this = yield
@@ -96,7 +97,7 @@ class NimCheckCurrentView(NimLimeOutputMixin, ApplicationCommand):
         # Run 'nim check' on the current view and retrieve the output.
         output, returncode = yield Thread(
             target=run_nimcheck,
-            args=(view.file_name(), this.send)
+            args=(view.file_name(), this.send, this.verbosity)
         ).start()
 
         messages = parse_nimcheck_output(output)
@@ -278,11 +279,11 @@ class NimCheckFile(NimLimeOutputMixin, ApplicationCommand):
 
 
 # Utility functions
-def run_nimcheck(file_path, callback):
+def run_nimcheck(file_path, callback, verbosity=2):
     # Prepare the regex's
     run_process(
-        "{0} check --verbosity:2 \"{1}\"".format(
-            nim_executable, file_path
+        "{0} check --verbosity:{1} \"{2}\"".format(
+            nim_executable, verbosity, file_path
         ),
         callback
     )

--- a/NimLime.sublime-settings
+++ b/NimLime.sublime-settings
@@ -156,6 +156,7 @@
 
     "check.on_save.highlight_errors": true,
     "check.on_save.highlight_warnings": false,
+    "check.on_save.verbosity": 2,
 
     "check.on_save.list.include_context": false,
     "check.on_save.list.move_cursor": true,
@@ -175,6 +176,7 @@
 
     "check.current_file.highlight_errors": true,
     "check.current_file.highlight_warnings": true,
+    "check.current_file.verbosity": 2,
 
     "check.current_file.list.include_context": false,
     "check.current_file.list.show_errors": false,


### PR DESCRIPTION
This would be a nice feature to have, so here's a quick PR with one way to do it. Note that this only supports `current_file` and `on_save` vs. `external_file` (which had a separate class and I wasn't sure if it makes sense to bother porting there as I rarely use that option and didn't dive into the result parsing).