### PR TITLE
Fixed import regex to include ../* and ./*

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -207,7 +207,7 @@ patterns:
   - {include: source.nim}
 
 - comment: Import syntax
-  match: ((import)\s+[\/\w]+,?)
+  match: ((import)\s+[\.|\w|\/]+,?)
   captures:
     '2': { name: keyword.control.nim }
 - match: (from)\s+[\/\w]+\s+(?=import)

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -572,7 +572,7 @@
 			<key>comment</key>
 			<string>Import syntax</string>
 			<key>match</key>
-			<string>((import)\s+[\/\w]+,?)</string>
+			<string>((import)\s+[\.|\w|\/]+,?)</string>
 		</dict>
 		<dict>
 			<key>captures</key>


### PR DESCRIPTION
`import ../foo` and `import ./bar` aren't matched by the old regex, despite being valid imports. Quick fix to the import regex fixes this.
