### PR TITLE
Nim Programming Language (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 NimLime
 =======
 
-Super Nim Plugin for Sublime Text 2/3
+Nim Programming Language plugin for Sublime Text 2/3
 
 Features
 --------


### PR DESCRIPTION
Replaces 'Super Nim' with 'Nim Programming Language' in the first line of the README.

I was super confused at first, why _super nim_?