### PR TITLE
Use explicit count modifiers

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -284,7 +284,7 @@ patterns:
       match: \\n
     - include: '#escaped_char'
     - name: invalid.illegal.character.nim
-      match: ([^\']{2,}?)   #' highlight-flaw-fixer-comment
+      match: ([^\'][^\']+?)   #' highlight-flaw-fixer-comment
 
 - comment: Call syntax
   begin: ([\w\x{80}-\x{10FFFF}\`]+)\s*(?=\(|\[.+?\]\s*\()

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -741,7 +741,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>([^\']{2,}?)</string>
+					<string>([^\'][^\']+?)</string>
 					<key>name</key>
 					<string>invalid.illegal.character.nim</string>
 				</dict>


### PR DESCRIPTION
The construction `{2,}` in regular expressions is only supported by Oniguruma (which is used by TextMate and Sublime Text). However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regular expressions.

This is a known issue that we've been fixing in many grammars. Unfortunately, [it doesn't seem to be source of the bug](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fgithub.com%2Fpchaigno%2FNimLime%2Fblob%2Fexplicit-count-modifiers%2FSyntaxes%2FNim.tmLanguage&grammar_text=&code_source=from-text&code_url=&code=let+hex+%3D+0xDEADBEEF%27u32%0D%0Alet+bin+%3D+0B0_10001110100_0000101001000111101011101111111011000101001101001001%27f64) you reported at github/linguist#3631.