### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -129,7 +129,7 @@ patterns:
 
 - comment: A hexadecimal literal
   name: constant.numeric.integer.hexadecimal.nim
-  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX]\h[_\h]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
+  match: (?<![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?   #' highlight-flaw-fixer-comment
 
 - comment: A base-8 integer literal
   name: constant.numeric.integer.octal.nim
@@ -592,7 +592,7 @@ repository:
     - name: constant.character.escape.escape.nim
       match: \\[eE]
     - name: constant.character.escape.hex.nim
-      match: \\[xX]\h\h
+      match: \\[xX][0-9A-Fa-f]{2}
     - name: constant.character.escape.backslash.nim
       match: \\\\
 ...

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -362,7 +362,7 @@
 			<key>comment</key>
 			<string>A hexadecimal literal</string>
 			<key>match</key>
-			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX]\h[_\h]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
+			<string>(?&lt;![\w\x{80}-\x{10FFFF}])(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('?(([iIuUfF](8|16|32|64))|[uUfFdD]))?</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.nim</string>
 		</dict>
@@ -1806,7 +1806,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\\[xX]\h\h</string>
+					<string>\\[xX][0-9A-Fa-f]{2}</string>
 					<key>name</key>
 					<string>constant.character.escape.hex.nim</string>
 				</dict>

--- a/Syntaxes/Nim_Cfg.YAML-tmLanguage
+++ b/Syntaxes/Nim_Cfg.YAML-tmLanguage
@@ -33,7 +33,7 @@ patterns:
     match: \b((\d[_\d]*\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*))('[fF](32|64))?
 
   - name: constant.numeric.integer.hexadecimal.nimcfg
-    match: \b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?
+    match: \b(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('[iIuU](8|16|32|64))?
 
   - comment: For simplicity's sake, we don't enforce floats only having 32 and
              64 prefix types.
@@ -64,7 +64,7 @@ patterns:
     captures:
       '1': {name: storage.type.function.nimcfg}
     patterns:
-    - match: (\\([abenrclftv\\]|["']|[0-9])|x\h\h)
+    - match: (\\([abenrclftv\\]|["']|[0-9])|x[0-9A-Fa-f]{2})
 
   - comment: Single quoted character literal
     name: string.quoted.single.nimcfg

--- a/Syntaxes/Nim_Cfg.tmLanguage
+++ b/Syntaxes/Nim_Cfg.tmLanguage
@@ -77,7 +77,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?</string>
+					<string>\b(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('[iIuU](8|16|32|64))?</string>
 					<key>name</key>
 					<string>constant.numeric.integer.hexadecimal.nimcfg</string>
 				</dict>
@@ -147,7 +147,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>(\\([abenrclftv\\]|["']|[0-9])|x\h\h)</string>
+							<string>(\\([abenrclftv\\]|["']|[0-9])|x[0-9A-Fa-f]{2})</string>
 						</dict>
 					</array>
 				</dict>

--- a/Syntaxes/Nim_Filter.YAML-tmLanguage
+++ b/Syntaxes/Nim_Filter.YAML-tmLanguage
@@ -15,7 +15,7 @@ patterns:
       match: \b((\d[_\d]*\.[_\d]+([eE][\+\-]?\d[_\d]*)?)|([eE][\+\-]?\d[_\d]*))('[fF](32|64))?
 
     - name: constant.numeric.integer.hexadecimal.nim_filter
-      match: \b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?
+      match: \b(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('[iIuU](8|16|32|64))?
 
     - comment: For simplicity's sake, we don't enforce floats only having 32 and
                64 prefix types.
@@ -89,7 +89,7 @@ patterns:
       begin: (\w[_\w]*)?\"
       end: \"
       patterns:
-      - match: (\\([abenrclftv]|["']|[0-9])|x\h\h)
+      - match: (\\([abenrclftv]|["']|[0-9])|x[0-9A-Fa-f]{2})
 
     - comment: Single quoted character literal
       name: string.quoted.single.nim_filter

--- a/Syntaxes/Nim_Filter.tmLanguage
+++ b/Syntaxes/Nim_Filter.tmLanguage
@@ -36,7 +36,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>\b(0[xX]\h[_\h]*)('[iIuU](8|16|32|64))?</string>
+							<string>\b(0[xX][0-9A-Fa-f][_0-9A-Fa-f]*)('[iIuU](8|16|32|64))?</string>
 							<key>name</key>
 							<string>constant.numeric.integer.hexadecimal.nim_filter</string>
 						</dict>
@@ -188,7 +188,7 @@
 							<array>
 								<dict>
 									<key>match</key>
-									<string>(\\([abenrclftv]|["']|[0-9])|x\h\h)</string>
+									<string>(\\([abenrclftv]|["']|[0-9])|x[0-9A-Fa-f]{2})</string>
 								</dict>
 							</array>
 						</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.

Fixes github/linguist#3631.