### PR TITLE
basic multiline doc comment support

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -14,6 +14,14 @@ patterns:
     '1': {name: punctuation.definition.multi-comment.nim}
     '2': {name: invalid.illegal.TODO.nim}
 
+- comment: A multiline documentation comment.
+  name: comment.line.number-sign.multi-doc-comment.nim
+  begin: (\#\#\[\s*(TODO|todo)?)
+  end: (.*]\#\#)
+  captures:
+    '1': {name: punctuation.definition.multi-doc-comment.nim}
+    '2': {name: invalid.illegal.TODO.nim}
+
 - comment: A documentation comment.
   name: comment.line.number-sign.doc-comment.nim
   match: (##\s*(TODO|todo)?).+$\n?

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -35,6 +35,29 @@
 			<string>comment.line.number-sign.multi-comment.nim</string>
 		</dict>
 		<dict>
+			<key>begin</key>
+			<string>(\#\#\[\s*(TODO|todo)?)</string>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.definition.multi-doc-comment.nim</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>invalid.illegal.TODO.nim</string>
+				</dict>
+			</dict>
+			<key>comment</key>
+			<string>A multiline documentation comment.</string>
+			<key>end</key>
+			<string>(.*]\#\#)</string>
+			<key>name</key>
+			<string>comment.line.number-sign.multi-doc-comment.nim</string>
+		</dict>
+		<dict>
 			<key>captures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
I added basic multiline doc comment to the syntax. After this change multiline docs looks exactly like single line docs. Tested on sublimeText 3.