### PR TITLE
'\n' is no longer invalid

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -288,8 +288,6 @@ patterns:
   begin: \'
   end: \'
   patterns:
-    - name: invalid.illegal.character.nim
-      match: \\n
     - include: '#escaped_char'
     - name: invalid.illegal.character.nim
       match: ([^\'][^\']+?)   #' highlight-flaw-fixer-comment

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -753,12 +753,6 @@
 			<key>patterns</key>
 			<array>
 				<dict>
-					<key>match</key>
-					<string>\\n</string>
-					<key>name</key>
-					<string>invalid.illegal.character.nim</string>
-				</dict>
-				<dict>
 					<key>include</key>
 					<string>#escaped_char</string>
 				</dict>


### PR DESCRIPTION
Github was rendering it incorrectly (see [here](https://github.com/nim-lang/Nim/pull/9527/commits/d5c78a448f3e47ec1871d9f15ef933d8896b27a5#diff-f383953c5790a09a0c47f1f640f76938R1472) for eg.)

I haven't tested it locally so hopefully no more changes are required. 
  
