### PR TITLE
Fix GitHub highlighting

### DIFF
--- a/Syntaxes/Nim.YAML-tmLanguage
+++ b/Syntaxes/Nim.YAML-tmLanguage
@@ -133,14 +133,14 @@ repository:
       - begin: for\b
         beginCaptures:
           '0': {name: keyword.control.loop.for.nim}
-        end: (in\b)|(?=[^#,{_`A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])
+        end: (in\b)|(?=[^#,{_`A-Za-z\s\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])
         endCaptures:
           '1': {name: keyword.control.loop.for.in.nim}
         patterns:
           - begin: \(
             beginCaptures:
               '0': {name: punctuation.section.parens.begin.nim}
-            end: '(in\b)|(\))|(?=[^#,{_`A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])'
+            end: '(in\b)|(\))|(?=[^#,{_`A-Za-z\s\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])'
             endCaptures:
               '1': {name: keyword.control.loop.for.in.nim}
               '2': {name: punctuation.section.parens.end.nim}
@@ -152,7 +152,7 @@ repository:
     patterns:
       - match: ','
         name: punctuation.separator.nim
-      - match: '[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`'
+      - match: '(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`'
       - include: '#pragmas'
       - include: '#comments'
 
@@ -206,7 +206,7 @@ repository:
 
   interpolation:
     patterns:
-      - match: '(`) *(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_) *(`)'
+      - match: '(`) *(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_) *(`)'
         captures:
           '0': {name: source.nim.embedded}
           '1': {name: punctuation.section.embedded.begin.nim}
@@ -216,7 +216,7 @@ repository:
     patterns:
       - begin: '(?x:
           (proc|template|iterator|func|method|macro|converter)\b
-          (?:[ ]*([A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`)(?:[ ]*(\*))?)?
+          (?:[ ]*((?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`)(?:[ ]*(\*))?)?
         )'
         beginCaptures:
           '1': {name: storage.type.function.nim}
@@ -277,7 +277,7 @@ repository:
           '0': {name: string.quoted.triple.nim punctuation.definition.string.end.nim}
         contentName: string.quoted.triple.nim
         patterns:
-          - match: '{{|}}'
+          - match: '\{\{|\}\}'
             name: constant.character.escape.nim
           - begin: '{'
             beginCaptures:
@@ -299,7 +299,7 @@ repository:
           '2': {name: invalid.illegal.nim}
         contentName: string.quoted.triple.nim
         patterns:
-          - match: '{{|}}|""'
+          - match: '\{\{|\}\}|""'
             name: constant.character.escape.nim
           - begin: '{'
             beginCaptures:
@@ -322,7 +322,7 @@ repository:
           '2': {name: invalid.illegal.nim}
         contentName: string.quoted.double.nim
         patterns:
-          - match: '{{|}}'
+          - match: '\{\{|\}\}'
             name: constant.character.escape.nim
           - begin: '{'
             beginCaptures:
@@ -346,10 +346,10 @@ repository:
 
   generic-param-list:
     patterns:
-      - begin: (?<=[`*\w\x{80}-\x{ff}]) *(\[)
+      - begin: (?<=(?<=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[`*\w\x{80}-\x{10FFFF}]) *(\[)
         beginCaptures:
           '1': {name: punctuation.section.generic.begin.nim}
-        end: '(])|(?=[^#_`:=,;A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])'
+        end: '(])|(?=[^#_`:=,;A-Za-z\x80-\x{10FFFF}\s]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])'
         endCaptures:
           '1': {name: punctuation.section.generic.end.nim}
         name: meta.generic.nim
@@ -382,7 +382,7 @@ repository:
         name: meta.annotation.nim
         patterns:
           - include: '#calls'
-          - match: '[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`'
+          - match: '(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`'
             name: entity.other.attribute-name.pragma.nim
           - include: '#square-brackets'
           - begin: (?=\S)
@@ -481,8 +481,8 @@ repository:
                ([Ee][-+]?\d(?:_?\d)*)?
               |([Ee][-+]?\d(?:_?\d)*)
             )
-             (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd]))?
-            |(''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd]))
+             (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd]))?
+            |(''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd]))
           )
         )'
         captures:
@@ -498,7 +498,7 @@ repository:
       - match: '(?x:
           \b(0[Xx])
           (\h(?:_?\h)*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|[Ff](?:32|64))
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|[Ff](?:32|64))
         )'
         captures:
           '0': {name: meta.number.float.hexadecimal.nim}
@@ -509,7 +509,7 @@ repository:
       - match: '(?x:
           \b(0o)
           ([0-7](?:_?[0-7])*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd]))
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd]))
         )'
         captures:
           '0': {name: meta.number.float.octal.nim}
@@ -520,7 +520,7 @@ repository:
       - match: '(?x:
           \b(0[Bb])
           ([01](?:_?[01])*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd]))
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd]))
         )'
         captures:
           '0': {name: meta.number.float.binary.nim}
@@ -532,7 +532,7 @@ repository:
       - match: '(?x:
           \b(0[Xx])
           (\h(?:_?\h)*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
         )'
         captures:
           '0': {name: meta.number.integer.hexadecimal.nim}
@@ -543,7 +543,7 @@ repository:
       - match: '(?x:
           \b(0o)
           ([0-7](?:_?[0-7])*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
         )'
         captures:
           '0': {name: meta.number.integer.octal.nim}
@@ -554,7 +554,7 @@ repository:
       - match: '(?x:
           \b(0[Bb])
           ([01](?:_?[01])*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
         )'
         captures:
           '0': {name: meta.number.integer.binary.nim}
@@ -564,7 +564,7 @@ repository:
 
       - match: '(?x:
           \b(\d(?:_?\d)*)
-          (''(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
+          (''(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))?
         )'
         captures:
           '0': {name: meta.number.integer.decimal.nim}
@@ -654,7 +654,7 @@ repository:
           '1': {name: keyword.control.flow.defer.nim}
           '2': {name: punctuation.section.block.begin.nim}
 
-      - match: '\b(block)\b(?:(?: *(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`))? *(:))?'
+      - match: '\b(block)\b(?:(?: *(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`))? *(:))?'
         captures:
           '1': {name: keyword.declaration.block.nim}
           '2': {name: punctuation.section.block.begin.nim}
@@ -682,7 +682,7 @@ repository:
           (?=
             (?:
               (?!(?:out|ptr|ref|tuple)\b)
-              [A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`
+              (?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}]))*|_|`[^;,\n`]+`
             )
             (?:\[.*])?
             (?:
@@ -695,22 +695,22 @@ repository:
                 |(?!(as|asm|and|bind|break|concept|const|continue|converter
                   |defer|discard|distinct|div|elif|else|end|except|export|finally|from|import
                   |include|interface|is(?:not)?|let|macro|method|mixin|mod|(?:not)?in|of
-                  |raise|sh[lr]|template|using|while|yield|x?or)\b)[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]]
+                  |raise|sh[lr]|template|using|while|yield|x?or)\b)(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}]
                 |\{(?!\.)
               )
             )
           )
         )'
-        end: '(?=[^\[\(`\w\x{80}-\x{ff}])|(?<=["\)])'
+        end: '(?=[^\[\(`\w\x{80}-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])|(?<=["\)])'
         patterns:
-          - begin: '(?=[`_A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])'
-            end: '(?=[^`_A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])'
+          - begin: '(?=(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[`_A-Za-z\x80-\x{10FFFF}])'
+            end: '(?=[^`_A-Za-z\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])'
             name: entity.name.function.nim
             patterns:
               - include: '#builtins'
-              - match: '[A-Z][\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]]+\b'
+              - match: '[A-Z](?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+\b'
                 name: support.type.nim
-              - match: '[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`'
+              - match: '(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`'
 
           - begin: '\[:?'
             beginCaptures:
@@ -745,9 +745,9 @@ repository:
 
   types:
     patterns:
-      - begin: '(?=(?:[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z])*)\[)(?x:(out|ptr|ref|array
+      - begin: '(?=(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*\[)(?x:(out|ptr|ref|array
           |cstring[Aa]rray|iterable|lent|open[Aa]rray|owned|ptr|range|ref|se[qt]
-          |sink|static|type(?:[Dd]esc)?|varargs)|([A-Z][\dA-Za-z]+))(\[)'
+          |sink|static|type(?:[Dd]esc)?|varargs)|(\p{Lu}(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+))(\[)'
         beginCaptures:
           '1': {name: storage.type.primitive.nim}
           '2': {name: support.type.nim}
@@ -782,8 +782,8 @@ repository:
 
   generic-symbols:
     patterns:
-      - match: '[A-Z](_?[A-Z\d\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])+\b'
+      - match: '\p{Lu}(?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Z\d\x80-\x{10FFFF}])+\b'
         name: support.constant.nim
-      - match: '[A-Z][\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]]+\b'
+      - match: '\p{Lu}(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+\b'
         name: support.type.nim
-      - match: '[A-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&&[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`'
+      - match: '(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`'

--- a/Syntaxes/Nim.tmLanguage
+++ b/Syntaxes/Nim.tmLanguage
@@ -421,16 +421,16 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?x: (?= (?: (?!(?:out|ptr|ref|tuple)\b) [A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+` ) (?:\[.*])? (?: \( |" |[ ]+ (?: [_\d"'`\[\(] |(?!\.|(?:\*?[ ]*)[:=]|=[^=])[-=+*/&lt;&gt;@$~&amp;%|!?^.:\\∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]+[^\-=+*/&lt;&gt;@$~&amp;%|!?^.:\\∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔\s] |(?!(as|asm|and|bind|break|concept|const|continue|converter |defer|discard|distinct|div|elif|else|end|except|export|finally|from|import |include|interface|is(?:not)?|let|macro|method|mixin|mod|(?:not)?in|of |raise|sh[lr]|template|using|while|yield|x?or)\b)[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]] |\{(?!\.) ) ) ) )</string>
+					<string>(?x: (?= (?: (?!(?:out|ptr|ref|tuple)\b) (?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}]))*|_|`[^;,\n`]+` ) (?:\[.*])? (?: \( |" |[ ]+ (?: [_\d"'`\[\(] |(?!\.|(?:\*?[ ]*)[:=]|=[^=])[-=+*/&lt;&gt;@$~&amp;%|!?^.:\\∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]+[^\-=+*/&lt;&gt;@$~&amp;%|!?^.:\\∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔\s] |(?!(as|asm|and|bind|break|concept|const|continue|converter |defer|discard|distinct|div|elif|else|end|except|export|finally|from|import |include|interface|is(?:not)?|let|macro|method|mixin|mod|(?:not)?in|of |raise|sh[lr]|template|using|while|yield|x?or)\b)(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}] |\{(?!\.) ) ) ) )</string>
 					<key>end</key>
-					<string>(?=[^\[\(`\w\x{80}-\x{ff}])|(?&lt;=["\)])</string>
+					<string>(?=[^\[\(`\w\x{80}-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])|(?&lt;=["\)])</string>
 					<key>patterns</key>
 					<array>
 						<dict>
 							<key>begin</key>
-							<string>(?=[`_A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])</string>
+							<string>(?=(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[`_A-Za-z\x80-\x{10FFFF}])</string>
 							<key>end</key>
-							<string>(?=[^`_A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])</string>
+							<string>(?=[^`_A-Za-z\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])</string>
 							<key>name</key>
 							<string>entity.name.function.nim</string>
 							<key>patterns</key>
@@ -441,13 +441,13 @@
 								</dict>
 								<dict>
 									<key>match</key>
-									<string>[A-Z][\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]]+\b</string>
+									<string>[A-Z](?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+\b</string>
 									<key>name</key>
 									<string>support.type.nim</string>
 								</dict>
 								<dict>
 									<key>match</key>
-									<string>[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`</string>
+									<string>(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`</string>
 								</dict>
 							</array>
 						</dict>
@@ -692,7 +692,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>{{|}}</string>
+							<string>\{\{|\}\}</string>
 							<key>name</key>
 							<string>constant.character.escape.nim</string>
 						</dict>
@@ -771,7 +771,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>{{|}}|""</string>
+							<string>\{\{|\}\}|""</string>
 							<key>name</key>
 							<string>constant.character.escape.nim</string>
 						</dict>
@@ -855,7 +855,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>{{|}}</string>
+							<string>\{\{|\}\}</string>
 							<key>name</key>
 							<string>constant.character.escape.nim</string>
 						</dict>
@@ -940,7 +940,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`</string>
+					<string>(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -968,7 +968,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(in\b)|(?=[^#,{_`A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])</string>
+					<string>(in\b)|(?=[^#,{_`A-Za-z\s\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -991,7 +991,7 @@
 								</dict>
 							</dict>
 							<key>end</key>
-							<string>(in\b)|(\))|(?=[^#,{_`A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])</string>
+							<string>(in\b)|(\))|(?=[^#,{_`A-Za-z\s\x80-\x{10FFFF}]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])</string>
 							<key>endCaptures</key>
 							<dict>
 								<key>1</key>
@@ -1027,7 +1027,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?&lt;=[`*\w\x{80}-\x{ff}]) *(\[)</string>
+					<string>(?&lt;=(?&lt;=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[`*\w\x{80}-\x{10FFFF}]) *(\[)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1037,7 +1037,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(])|(?=[^#_`:=,;A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]\s])</string>
+					<string>(])|(?=[^#_`:=,;A-Za-z\x80-\x{10FFFF}\s]|[∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])</string>
 					<key>endCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1114,19 +1114,19 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>[A-Z](_?[A-Z\d\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])+\b</string>
+					<string>\p{Lu}(?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Z\d\x80-\x{10FFFF}])+\b</string>
 					<key>name</key>
 					<string>support.constant.nim</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>[A-Z][\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]]+\b</string>
+					<string>\p{Lu}(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+\b</string>
 					<key>name</key>
 					<string>support.type.nim</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`</string>
+					<string>(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`</string>
 				</dict>
 			</array>
 		</dict>
@@ -1154,7 +1154,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(`) *(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_) *(`)</string>
+					<string>(`) *(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_) *(`)</string>
 				</dict>
 			</array>
 		</dict>
@@ -1361,7 +1361,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(block)\b(?:(?: *(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`))? *(:))?</string>
+					<string>\b(block)\b(?:(?: *(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`))? *(:))?</string>
 				</dict>
 				<dict>
 					<key>match</key>
@@ -1509,7 +1509,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(\d(?:_?\d)*) (?: (?: ((\.)\d(?:_?\d)*) ([Ee][-+]?\d(?:_?\d)*)? |([Ee][-+]?\d(?:_?\d)*) ) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd]))? |('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd])) ) )</string>
+					<string>(?x: \b(\d(?:_?\d)*) (?: (?: ((\.)\d(?:_?\d)*) ([Ee][-+]?\d(?:_?\d)*)? |([Ee][-+]?\d(?:_?\d)*) ) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd]))? |('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd])) ) )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1536,7 +1536,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0[Xx]) (\h(?:_?\h)*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|[Ff](?:32|64)) )</string>
+					<string>(?x: \b(0[Xx]) (\h(?:_?\h)*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|[Ff](?:32|64)) )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1563,7 +1563,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0o) ([0-7](?:_?[0-7])*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd])) )</string>
+					<string>(?x: \b(0o) ([0-7](?:_?[0-7])*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd])) )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1590,7 +1590,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0[Bb]) ([01](?:_?[01])*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[Ff](?:32|64)|[Dd])) )</string>
+					<string>(?x: \b(0[Bb]) ([01](?:_?[01])*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[Ff](?:32|64)|[Dd])) )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1617,7 +1617,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0[Xx]) (\h(?:_?\h)*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
+					<string>(?x: \b(0[Xx]) (\h(?:_?\h)*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1644,7 +1644,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0o) ([0-7](?:_?[0-7])*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
+					<string>(?x: \b(0o) ([0-7](?:_?[0-7])*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1671,7 +1671,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(0[Bb]) ([01](?:_?[01])*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
+					<string>(?x: \b(0[Bb]) ([01](?:_?[01])*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
 				</dict>
 				<dict>
 					<key>captures</key>
@@ -1693,7 +1693,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?x: \b(\d(?:_?\d)*) ('(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
+					<string>(?x: \b(\d(?:_?\d)*) ('(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_)|(?:[IUiu](?:8|16|32|64)|[Uu]))? )</string>
 				</dict>
 			</array>
 		</dict>
@@ -1892,7 +1892,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`</string>
+							<string>(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`</string>
 							<key>name</key>
 							<string>entity.other.attribute-name.pragma.nim</string>
 						</dict>
@@ -2001,7 +2001,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?x: (proc|template|iterator|func|method|macro|converter)\b (?:[ ]*([A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]])*|_|`[^;,\n`]+`)(?:[ ]*(\*))?)? )</string>
+					<string>(?x: (proc|template|iterator|func|method|macro|converter)\b (?:[ ]*((?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*|_|`[^;,\n`]+`)(?:[ ]*(\*))?)? )</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -2249,7 +2249,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?=(?:[A-Za-z\x80-\x{10FFFF}&amp;&amp;[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔]](?:_?[\dA-Za-z])*)\[)(?x:(out|ptr|ref|array |cstring[Aa]rray|iterable|lent|open[Aa]rray|owned|ptr|range|ref|se[qt] |sink|static|type(?:[Dd]esc)?|varargs)|([A-Z][\dA-Za-z]+))(\[)</string>
+					<string>(?=(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[A-Za-z\x80-\x{10FFFF}](?:_?(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])*\[)(?x:(out|ptr|ref|array |cstring[Aa]rray|iterable|lent|open[Aa]rray|owned|ptr|range|ref|se[qt] |sink|static|type(?:[Dd]esc)?|varargs)|(\p{Lu}(?:(?=[^∙∘×★⊗⊘⊙⊛⊠⊡∩∧⊓±⊕⊖⊞⊟∪∨⊔])[\dA-Za-z\x80-\x{10FFFF}])+))(\[)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>


### PR DESCRIPTION
Github's highlighter uses PCRE while Sublime Text uses Oniguruma. Apparenly set intersection is supported by oniguruma, but not PCRE.